### PR TITLE
[review] locale未指定の場合は全localeの文言を返すように

### DIFF
--- a/src/fetchBlurbs.ts
+++ b/src/fetchBlurbs.ts
@@ -1,8 +1,11 @@
 import * as functions from 'firebase-functions';
 import { fetchPublishedBlurbs, fetchDraftBlurbs } from './lib/copyTuner';
-import { CopyTunerBlurbs } from './types';
+import { CopyTunerBlurbs, CopyTunerBlurbsByLocale } from './types';
 
-export const fetchBlurbs = async (data: { environment: string; locale?: string }): Promise<CopyTunerBlurbs> => {
+export const fetchBlurbs = async (data: {
+  environment: string;
+  locale?: string;
+}): Promise<CopyTunerBlurbs | CopyTunerBlurbsByLocale> => {
   const { locale, environment } = data;
   const {
     copy_tuner: { s3_host: host, api_key: apiKey },

--- a/src/lib/copyTuner.ts
+++ b/src/lib/copyTuner.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { CopyTunerBlurbs } from '../types';
+import { CopyTunerBlurbs, CopyTunerBlurbsByLocale } from '../types';
 
 const blurbsByLocale = ({ data, locale }) => {
   // eslint-disable-next-line no-useless-escape
@@ -28,14 +28,22 @@ type fetchBlurbsOptions = {
   locale?: string;
 };
 
-export const fetchPublishedBlurbs = async ({ host, apiKey, locale }: fetchBlurbsOptions): Promise<CopyTunerBlurbs> => {
+export const fetchPublishedBlurbs = async ({
+  host,
+  apiKey,
+  locale,
+}: fetchBlurbsOptions): Promise<CopyTunerBlurbs | CopyTunerBlurbsByLocale> => {
   const url = `${host}/api/v2/projects/${apiKey}/published_blurbs.json`;
   const { data } = await axios.get(url);
 
   return blurbs({ data, locale });
 };
 
-export const fetchDraftBlurbs = async ({ host, apiKey, locale }: fetchBlurbsOptions): Promise<CopyTunerBlurbs> => {
+export const fetchDraftBlurbs = async ({
+  host,
+  apiKey,
+  locale,
+}: fetchBlurbsOptions): Promise<CopyTunerBlurbs | CopyTunerBlurbsByLocale> => {
   const url = `${host}/api/v2/projects/${apiKey}/draft_blurbs.json`;
   const { data } = await axios.get(url);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
-export type CopyTunerBlurbs = {
+export type CopyTunerBlurbsByLocale = {
   [key: string]: string;
+};
+
+export type CopyTunerBlurbs = {
+  [key: string]: CopyTunerBlurbsByLocale;
 };
 
 export type CopyTunerConfig = {


### PR DESCRIPTION
react-i18nextは最初に全ロケールの文言を設定する形式なので一応そちらにも対応できるようにlocale未指定の場合は全ロケールの文言を返す機能を追加